### PR TITLE
remove uri encode causing custom script issue

### DIFF
--- a/src/android/HostedWebApp.java
+++ b/src/android/HostedWebApp.java
@@ -552,7 +552,7 @@ public class HostedWebApp extends CordovaPlugin {
                             evaluateJavaScriptMethod.invoke(webView, scriptToInject, resultCallback);
                         } catch (Exception e) {
                             Log.v(LOG_TAG, String.format("WARNING: Webview does not support 'evaluateJavascript' method. Webview type: '%s'", webView.getClass().getName()));
-                            me.webView.getEngine().loadUrl("javascript:" + Uri.encode(scriptToInject), false);
+                            me.webView.getEngine().loadUrl("javascript:" + scriptToInject, false);
 
                             if (resultCallback != null) {
                                 resultCallback.onReceiveValue(null);


### PR DESCRIPTION
reproduced on jelly bean only.  later versions (22) work as expected using evaluateJavascript path.
https://github.com/manifoldjs/ManifoldCordova/issues/64 - systemwebview does not like uri encoded content in loadurl.  this seems fine to remove for javascript: prefixed scripts with unescaped characters.
