### PR TITLE
Fixed several Android issues related to version and loading of plugins in client mode.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,7 +26,7 @@
     <engines>
         <engine name="cordova-windows" version="<=4.1.0" />
         <engine name="cordova-ios" version="<=3.9.2" />
-        <engine name="cordova-android" version="<=4.1.1" />
+        <engine name="cordova-android" version="<=5.1.1" />
     </engines>
 
     <!-- android -->

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 -->
 
 # Hosted Web Application
-This plugin enables the creation of a hosted web application from a [W3C manifest](http://www.w3.org/2008/webapps/manifest/) that provides metadata associated with a web site. It uses properties in the manifest to update corresponding properties in the Cordova configuration file to enable using content hosted in the site inside a Cordova application.
+This plugin enables the creation of a hosted web application from a [W3C manifest](http://www.w3.org/2008/webapps/manifest/) that provides metadata associated with a web site. It uses properties in the manifest to update corresponding properties in the Cordova configuration file to enable using content hosted in the site inside a Cordova application. This version of the code works with Android 5.1.1 and below: the original code base only worked with Android 4.1.1 and below.
 
 **Typical manifest** 
 <pre>

--- a/src/android/HostedWebApp.java
+++ b/src/android/HostedWebApp.java
@@ -50,6 +50,7 @@ public class HostedWebApp extends CordovaPlugin {
     private boolean offlineOverlayEnabled;
 
     private boolean isConnectionError = false;
+    private boolean isClientMode = false;
 
     @Override
     public void pluginInitialize() {
@@ -157,8 +158,16 @@ public class HostedWebApp extends CordovaPlugin {
         }
 
 		if (action.equals("injectPluginScript")) {
+            String temp;
 			final List<String> scripts = new ArrayList<String>();
-			scripts.add(args.getString(0));
+            if(this.isClientMode){
+                String clientPlugin = args.getString(0);
+                int ind = clientPlugin.indexOf("plugin");
+                clientPlugin = clientPlugin.substring(ind);
+                scripts.add(clientPlugin);
+            }else{
+                scripts.add(args.getString(0));
+            }
 
             cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
@@ -305,10 +314,12 @@ public class HostedWebApp extends CordovaPlugin {
 
                 List<String> scriptList = new ArrayList<String>();
                 if (pluginMode.equals("client")) {
+                    this.isClientMode = true;
                     scriptList.add("cordova.js");
                 }
 
                 scriptList.add("hostedapp-bridge.js");
+                scriptList.add("cordova_plugins.js");
                 injectScripts(scriptList, null);
             }
         }

--- a/src/android/HostedWebApp.java
+++ b/src/android/HostedWebApp.java
@@ -158,7 +158,6 @@ public class HostedWebApp extends CordovaPlugin {
         }
 
 		if (action.equals("injectPluginScript")) {
-            String temp;
 			final List<String> scripts = new ArrayList<String>();
             if(this.isClientMode){
                 String clientPlugin = args.getString(0);


### PR DESCRIPTION
There were several issue that prevented using this plugin in client side mode:
1. The Android version was limited to 4.1.1, I changed it to 5.1.1
2. In client side mode, the plugin attempted to load the plugins from the web site and not locally. 

I made several changes that now allows the plugin to load all the plugins from the client side (native side) and requiring no changes to the web site. 
I am now using this plugin to wrap an Angular 2 application that makes plugin calls without the need to modify the Angular 2 app.
